### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -14,6 +14,8 @@ env:
   ARTIFACT_NAME: openshock-landingpage.zip
   NODE_ENV: production
 
+permissions:
+  contents: read
 jobs:
 
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/OpenShock/OpenShock.org/security/code-scanning/1](https://github.com/OpenShock/OpenShock.org/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow. The best way is to add it at the root level (above `jobs:`), so it applies to all jobs unless overridden. For most build/test workflows that do not need to write to the repository, the minimal permission is `contents: read`. If the workflow needs to create or update pull requests, or perform other write actions, those permissions should be added as needed. In this case, the workflow only checks out code, installs dependencies, builds, compresses, and uploads artifacts, so `contents: read` is sufficient. Edit `.github/workflows/ci-build.yml` to add:

```yaml
permissions:
  contents: read
```

above the `jobs:` key (i.e., after the `env:` block).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
