### PR TITLE
security: Pin Github Actions

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -21,13 +21,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d  # v6.0.5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: 25.2.0
           cache: 'pnpm'
@@ -47,7 +47,7 @@ jobs:
           mv build/${{ env.ARTIFACT_NAME }} .
 
       - name: Upload internal artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: ${{ env.ARTIFACT_NAME }}
           path: ${{ github.workspace }}/${{ env.ARTIFACT_NAME }}


### PR DESCRIPTION
Pins all third-party GitHub Actions in workflows and composite actions to immutable commit SHAs, with the resolved tag preserved in a trailing comment.

Generated by `pin_github_actions.py`.